### PR TITLE
cards: Allow collapsed only if collapsible is TRUE

### DIFF
--- a/R/cards.R
+++ b/R/cards.R
@@ -122,7 +122,7 @@ bs4Card <- function(..., title = NULL, footer = NULL, status = NULL, elevation =
     }
   }
     
-  if (isTRUE(collapsed)) cardCl <- paste0(cardCl, " collapsed-card")
+  if (isTRUE(collapsible) & isTRUE(collapsed)) cardCl <- paste0(cardCl, " collapsed-card")
   if (!is.null(elevation)) cardCl <- paste0(cardCl, " elevation-", elevation)
   
   cardToolTag <- shiny::tags$div(


### PR DESCRIPTION
Even if this has no sense, if user set `collapsed=TRUE` and `collapsible=FALSE`, then the card is hidden and there is no way to show the content because there is no button. This would make sense to allow `collapsed` only if `collapsible=TRUE`. 

	modified :         R/cards.R