### PR TITLE
Propose empty title card

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,6 +4,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
+^pkgdown$
 ^_pkgdown\.yml$
 ^docs$
 ^cran-comments\.md$

--- a/R/cards.R
+++ b/R/cards.R
@@ -176,6 +176,8 @@ bs4Card <- function(..., title = NULL, footer = NULL, status = NULL, elevation =
   )
   
   # header
+  if (is.null(title) & (isTRUE(closable) | isTRUE(collapsible))) title <- "\u200C"
+  
   headerTag <- shiny::tags$div(
     class = if (isTRUE(headerBorder)) "card-header" else "card-header no-border",
     if (!is.null(title)) shiny::tags$h3(class = "card-title", title) else NULL


### PR DESCRIPTION
This is a proposition. 

> cards: allow empty title if tools needed

Add an no-width character as title if collapsible and/or closable is
TRUE. Otherwise, without Title, there is no tools available in the card header.

	modified :         R/cards.R

> Also modifies Rbuildignore to avoid NOTE with "pkgdown" directory