### PR TITLE
bs4TabCard: Allow background and header colours like cards

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ add an id argument.
 - fix #14: remove `bs4TabCard()` max-height attribute. Thanks @stephLH
 - add hex icon
 - add menuIcon arg and align arg to `bs4DropdownMenu()`, add id arg to `bs4DashControlbar()` PR by @bjornlind 
+- add background and header colours like cards to `bs4TabCard()`. PR by @statnmap
 
 ## Bug fix
 - Fix #19: Whenever a `bs4Card()` starts on a collapsed state, the content is displayed when

--- a/R/deps.R
+++ b/R/deps.R
@@ -15,6 +15,7 @@ addDeps <- function(x, theme) {
   # put all necessary ressources here
   adminLTE3_js <- "adminlte.js"
   bs4Dash_js <- "bs4Dash.js"
+  bs4Dash_css <- "bs4Dash.css"
   adminLTE3_css <- "adminlte.min.css"
   jquery_ui_js <- "jquery-ui.min.js"
   bootstrap_js <- "bootstrap.bundle.min.js"
@@ -51,7 +52,8 @@ addDeps <- function(x, theme) {
       name = "bs4Dash",
       version = as.character(utils::packageVersion("bs4Dash")),
       src = c(file = system.file("bs4Dash-0.2.0", package = "bs4Dash")),
-      script = bs4Dash_js
+      script = bs4Dash_js,
+      stylesheet = bs4Dash_css
     ),
     # fontawesome
     htmltools::htmlDependency(

--- a/bs4Dash.Rproj
+++ b/bs4Dash.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/inst/bs4Dash-0.2.0/bs4Dash.css
+++ b/inst/bs4Dash-0.2.0/bs4Dash.css
@@ -1,0 +1,43 @@
+.nav-item {
+    background-color: transparent !important;
+}
+
+.bg-primary .nav-link.active {
+    background-color: #007bff!important
+}
+
+.bg-secondary .nav-link.active {
+    background-color: #6c757d!important
+}
+
+.bg-success .nav-link.active {
+    background-color: #28a745!important
+}
+
+.bg-info .nav-link.active {
+    background-color: #17a2b8!important
+}
+
+.bg-warning .nav-link.active {
+    background-color: #ffc107!important
+}
+
+.bg-danger .nav-link.active {
+    background-color: #dc3545!important
+}
+
+.bg-light .nav-link.active {
+    background-color: #f8f9fa!important
+}
+
+.bg-dark .nav-link.active {
+    background-color: #343a40!important
+}
+
+.bg-white .nav-link.active {
+    background-color: #fff!important
+}
+
+.bg-transparent .nav-link.active {
+    background-color: transparent!important
+}

--- a/inst/examples/showcase/classic/global.R
+++ b/inst/examples/showcase/classic/global.R
@@ -12,7 +12,7 @@ df <- data.frame(x, y1 = sin(x), y2 = cos(x))
 x <- rnorm(200)
 y <- rnorm(200)
 
-
+#' basic_cards_tab ----
 basic_cards_tab <- bs4TabItem(
   tabName = "cards",
   fluidRow(
@@ -58,7 +58,7 @@ basic_cards_tab <- bs4TabItem(
   )
 )
 
-
+#' social_cards_tab ----
 social_cards_tab <- bs4TabItem(
   tabName = "socialcards",
   fluidRow(
@@ -190,7 +190,7 @@ social_cards_tab <- bs4TabItem(
   )
 )
 
-
+# tab_cards_tab ----
 tab_cards_tab <- bs4TabItem(
   tabName = "tabcards",
   fluidRow(
@@ -249,6 +249,8 @@ tab_cards_tab <- bs4TabItem(
         side = "right",
         elevation = 2,
         width = 12,
+        status = "warning",
+        tabStatus = c("dark", "danger", "transparent"),
         bs4TabPanel(
           tabName = "Tab 4",
           active = FALSE,
@@ -295,7 +297,7 @@ tab_cards_tab <- bs4TabItem(
 )
 
 
-
+# sortable_cards_tab ----
 sortable_cards_tab <- bs4TabItem(
   tabName = "sortablecards",
   fluidRow(
@@ -316,7 +318,7 @@ sortable_cards_tab <- bs4TabItem(
 )
 
 
-
+# statsboxes_tab ----
 statsboxes_tab <- bs4TabItem(
   tabName = "statsboxes",
   fluidRow(
@@ -388,7 +390,7 @@ statsboxes_tab <- bs4TabItem(
 )
 
 
-
+# boxes_tab ----
 boxes_tab <- bs4TabItem(
   tabName = "boxes",
   fluidRow(
@@ -407,7 +409,7 @@ boxes_tab <- bs4TabItem(
 
 
 
-
+# value_boxes_tab ----
 value_boxes_tab <- bs4TabItem(
   tabName = "valueboxes",
   h4("Value Boxes"),
@@ -462,7 +464,7 @@ value_boxes_tab <- bs4TabItem(
 )
 
 
-
+# gallery_1_tab ----
 gallery_1_tab <- bs4TabItem(
   tabName = "gallery1",
   fluidRow(
@@ -676,7 +678,7 @@ gallery_1_tab <- bs4TabItem(
 )
 
 
-
+# gallery_2_tab ----
 gallery_2_tab <- bs4TabItem(
   tabName = "gallery2",
   bs4Jumbotron(

--- a/man/bs4Card.Rd
+++ b/man/bs4Card.Rd
@@ -18,7 +18,7 @@ bs4Card(..., title = NULL, footer = NULL, status = NULL,
 
 \item{footer}{Optional footer text.}
 
-\item{status}{The status of the card header. "primary", "success", "warning", "danger". NULL by default.}
+\item{status}{The status of the card header. "primary", "secondary", "success", "warning", "danger", "white", "light", "dark". NULL by default.}
 
 \item{elevation}{Card elevation.}
 
@@ -47,7 +47,7 @@ the user to collapse the box.}
 
 \item{closable}{If TRUE, display a button in the upper right that allows the user to close the box.}
 
-\item{labelStatus}{status of the box label: "danger", "success", "primary", "warning".}
+\item{labelStatus}{status of the box label: "primary", "secondary", "success", "warning", "danger", "white", "light", "dark".}
 
 \item{labelText}{Label text.}
 

--- a/man/bs4TabCard.Rd
+++ b/man/bs4TabCard.Rd
@@ -4,13 +4,31 @@
 \alias{bs4TabCard}
 \title{Create a Boostrap 4 tabCard}
 \usage{
-bs4TabCard(..., title = NULL, width = 6, height = NULL,
-  elevation = NULL, side = c("left", "right"))
+bs4TabCard(..., title = NULL, status = NULL, elevation = NULL,
+  solidHeader = FALSE, headerBorder = TRUE, gradientColor = NULL,
+  tabStatus = NULL, width = 6, height = NULL, side = c("left",
+  "right"))
 }
 \arguments{
 \item{...}{Contents of the box: should be \link{bs4TabPanel}.}
 
 \item{title}{TabCard title.}
+
+\item{status}{The status of the card header. "primary", "secondary", "success", "warning", "danger", "white", "light", "dark". NULL by default.}
+
+\item{elevation}{tabCard elevation.}
+
+\item{solidHeader}{Should the header be shown with a solid color background?}
+
+\item{headerBorder}{Whether to display a border between the header and body.
+TRUE by default}
+
+\item{gradientColor}{If NULL (the default), the background of the box will be
+white. Otherwise, a color string. "primary", "success", "warning" or "danger".}
+
+\item{tabStatus}{The status of the tabs buttons over header. "primary", "secondary", "success", "warning", "danger", "white", "light", "dark".
+NULL by default, "light" if status is set.   
+A vector is possible with a colour for each tab button}
 
 \item{width}{The width of the box, using the Bootstrap grid system. This is
 used for row-based layouts. The overall width of a region is 12, so the
@@ -20,8 +38,6 @@ contains the box.}
 
 \item{height}{The height of a box, in pixels or other CSS unit. By default
 the height scales automatically with the content.}
-
-\item{elevation}{tabCard elevation.}
 
 \item{side}{Side of the box the tabs should be on (\code{"left"} or
 \code{"right"}).}

--- a/man/bs4TabSetPanel.Rd
+++ b/man/bs4TabSetPanel.Rd
@@ -4,13 +4,19 @@
 \alias{bs4TabSetPanel}
 \title{Create a tabSetPanel}
 \usage{
-bs4TabSetPanel(..., side)
+bs4TabSetPanel(..., side, status = NULL, tabStatus = NULL)
 }
 \arguments{
 \item{...}{Slot for \link{bs4TabPanel}.}
 
 \item{side}{Side of the box the tabs should be on (\code{"left"} or
 \code{"right"}).}
+
+\item{status}{The status of the card header. "primary", "secondary", "success", "warning", "danger", "white", "light", "dark". NULL by default.}
+
+\item{tabStatus}{The status of the tabs buttons over header. "primary", "secondary", "success", "warning", "danger", "white", "light", "dark".
+NULL by default, "light" if status is set.   
+A vector is possible with a colour for each tab button}
 }
 \description{
 Imported by bs4TabCard. Do not use outside!


### PR DESCRIPTION
- Allow to define different colour for each tab button
- Update list of colours available for status in documentation
- Added a new css file to allow for tab buttons colour

	modifié :         R/cards.R
	modifié :         R/deps.R
	modifié :         bs4Dash.Rproj
	nouveau fichier : inst/bs4Dash-0.2.0/bs4Dash.css
	modifié :         inst/examples/showcase/classic/global.R
	modifié :         man/bs4Card.Rd
	modifié :         man/bs4TabCard.Rd
	modifié :         man/bs4TabSetPanel.Rd

> Also updated showcase app:

![image](https://user-images.githubusercontent.com/21193866/51919887-a0467b00-23e4-11e9-8157-b16dc98721ee.png)

