### PR TITLE
bs4TabCard: collapsible and closable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # bs4Dash 0.3.0
 ## Major changes
+- add collapsible and closable to `bs4TabCard()`. Buttons visible by default. PR by @statnmap
 - add preloader options to `bs4DashPage`
 - move to RinteRface
 - add `bs4Sortable()` and all necessary javascript dependencies

--- a/R/cards.R
+++ b/R/cards.R
@@ -598,6 +598,7 @@ bs4TabCard <- function(..., title = NULL, status = NULL, elevation = NULL,
                        solidHeader = FALSE, headerBorder = TRUE, gradientColor = NULL,
                        tabStatus = NULL,
                        width = 6, height = NULL,  
+                       collapsible = TRUE, collapsed = FALSE, closable = TRUE,
                        side = c("left", "right")) {
   
   found_active <- FALSE
@@ -616,9 +617,44 @@ bs4TabCard <- function(..., title = NULL, status = NULL, elevation = NULL,
       }
     }
   }
+  if (isTRUE(collapsible) & isTRUE(collapsed)) tabCardCl <- paste0(tabCardCl, " collapsed-card")
   if (!is.null(elevation)) tabCardCl <- paste0(tabCardCl, " elevation-", elevation)
   
+  # tools collapse/closable
+  if (isTRUE(closable) | isTRUE(collapsible)) {
+  cardToolTag <- shiny::tags$div(
+    class = "tools pt-3 pb-3 pr-2 mr-2",
+
+    # collapse
+    if (isTRUE(collapsible)) {
+      collapseIcon <- if (collapsed) 
+        "plus"
+      else "minus"
+      shiny::tags$button(
+        type = "button",
+        class = "btn btn-tool pb-0 pt-0",
+        `data-widget` = "collapse",
+        shiny::icon(collapseIcon)
+      )
+    },
+    
+    # close
+    if (isTRUE(closable)) {
+      shiny::tags$button(
+        type = "button",
+        class = "btn btn-tool pb-0 pt-0",
+        `data-widget` = "remove",
+        shiny::tags$i(class = "fa fa-times")
+      )
+    }
+  )
+  } else {
+    cardToolTag <- shiny::tags$div()
+  }
+  
   # header
+  if (is.null(title) & (isTRUE(closable) | isTRUE(collapsible))) title <- "\u200C"
+  
   headerTag <- shiny::tags$div(
     class = if (isTRUE(headerBorder)) "card-header d-flex p-0" else "card-header d-flex p-0 no-border",
     if (side == "right") {
@@ -631,11 +667,13 @@ bs4TabCard <- function(..., title = NULL, status = NULL, elevation = NULL,
       shiny::tagList(
         # tab menu
         bs4TabSetPanel(..., side = side, tabStatus = tabStatus),
-        if (!is.null(title)) shiny::tags$h3(class = "card-title p-3 ml-auto", title) else NULL
+          if (!is.null(title)) shiny::tags$h3(class = "card-title p-3 ml-auto", title) else NULL
       )
     }
     
   )
+  headerTag <- if (!is.null(title)) shiny::tagAppendChild(headerTag, cardToolTag)
+  
   
   # body
   panels <- list(...)

--- a/inst/examples/showcase/classic/global.R
+++ b/inst/examples/showcase/classic/global.R
@@ -200,6 +200,7 @@ tab_cards_tab <- bs4TabItem(
         title = "A card with tabs",
         elevation = 2,
         width = 12,
+        collapsible = FALSE, closable = TRUE,
         bs4TabPanel(
           tabName = "Tab 1",
           active = FALSE,
@@ -245,12 +246,12 @@ tab_cards_tab <- bs4TabItem(
     column(
       width = 6,
       bs4TabCard(
-        title = "A card with tabs",
+        title = "A card with tabs on right",
         side = "right",
         elevation = 2,
         width = 12,
         status = "warning",
-        tabStatus = c("dark", "danger", "transparent"),
+        tabStatus = c("dark", "danger", "primary"),
         bs4TabPanel(
           tabName = "Tab 4",
           active = FALSE,

--- a/man/bs4TabCard.Rd
+++ b/man/bs4TabCard.Rd
@@ -6,8 +6,8 @@
 \usage{
 bs4TabCard(..., title = NULL, status = NULL, elevation = NULL,
   solidHeader = FALSE, headerBorder = TRUE, gradientColor = NULL,
-  tabStatus = NULL, width = 6, height = NULL, side = c("left",
-  "right"))
+  tabStatus = NULL, width = 6, height = NULL, collapsible = TRUE,
+  collapsed = FALSE, closable = TRUE, side = c("left", "right"))
 }
 \arguments{
 \item{...}{Contents of the box: should be \link{bs4TabPanel}.}
@@ -38,6 +38,14 @@ contains the box.}
 
 \item{height}{The height of a box, in pixels or other CSS unit. By default
 the height scales automatically with the content.}
+
+\item{collapsible}{If TRUE, display a button in the upper right that allows
+the user to collapse the box.}
+
+\item{collapsed}{If TRUE, start collapsed. This must be used with
+\code{collapsible=TRUE}.}
+
+\item{closable}{If TRUE, display a button in the upper right that allows the user to close the box.}
 
 \item{side}{Side of the box the tabs should be on (\code{"left"} or
 \code{"right"}).}


### PR DESCRIPTION
- add collapsible and closable buttons with options to show or not like
for bs4Card. Default to collapsible = TRUE and closable = TRUE
- Modified showcase to show buttons
- updated NEWS.

	modifié :         NEWS.md
	modifié :         R/cards.R
	modifié :         inst/examples/showcase/classic/global.R
	modifié :         man/bs4TabCard.Rd

![image](https://user-images.githubusercontent.com/21193866/55228885-a48fe880-521b-11e9-8896-dd7dab14d4df.png)
