### PR TITLE
id not required for tabBox + text align fix menuItems

### DIFF
--- a/R/cards.R
+++ b/R/cards.R
@@ -1105,7 +1105,7 @@ bs4InfoBox <- function(title, value = NULL, subtitle = NULL, icon = shiny::icon(
 #' @author David Granjon, \email{dgranjon@@ymail.com}
 #'
 #' @export
-bs4TabCard <- function(..., id, selected = NULL, title = NULL, width = 6,
+bs4TabCard <- function(..., id = NULL, selected = NULL, title = NULL, width = 6,
                        height = NULL, side = c("left", "right"), type = NULL,
                        footer = NULL, status = NULL, solidHeader = FALSE, background = NULL,
                        collapsible = TRUE, collapsed = FALSE, closable = FALSE, maximizable = FALSE,

--- a/R/dashboardSidebar.R
+++ b/R/dashboardSidebar.R
@@ -365,7 +365,7 @@ bs4SidebarMenuItem <- function(text, ..., icon = NULL, badgeLabel = NULL, badgeC
 
   if (!is.null(icon)) {
     tagAssert(icon, type = "i")
-    icon$attribs$cl <- paste0(icon$attribs$cl, " nav-icon")
+    icon$attribs$class <- paste0(icon$attribs$class, " nav-icon")
   }
 
   if (!is.null(href) + !is.null(tabName) + (length(subItems) > 0) != 1) {


### PR DESCRIPTION
- I noticed a tiny incompatibility issue between `shinydashboard` and `bs4Dash` : the `id` argument to tabBox (bs4TabCard) should not be required (it is also not required for bs4Card).

- the class attribute 'nav-icon' for a menuItem was not assigned, this led to poor aligning of icons and text in menuItem items. 

Thanks for making this package!