### PR TITLE
fix preloader: no longer breaks waiter

### DIFF
--- a/R/dashboardPage.R
+++ b/R/dashboardPage.R
@@ -185,8 +185,12 @@ bs4DashPage <- function(header, sidebar, body, controlbar = NULL, footer = NULL,
           paste0(
             "window.ran = false;",
             "$(document).on('shiny:idle', function(event){
-            if(!window.ran)
+            if(!window.ran){
               $('.waiter-overlay').fadeOut(1000);
+              setTimeOut(function(){
+                $('.waiter-overlay').remove();
+              }, 1200);
+            }
             window.ran = true;
           });"
           )


### PR DESCRIPTION
Hi David,

The current implementation of the preloader breaks waiter, see https://github.com/JohnCoene/waiter/issues/93

This fixes that issue.