### PR TITLE
Update waiter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     htmltools (>= 0.5.1.1),
     jsonlite (>= 0.9.16),
     fresh,
-    waiter,
+    waiter (>= 0.2.3),
     httpuv (>= 1.5.2),
     lifecycle,
     bslib (>= 0.2.4),

--- a/R/dashboardPage.R
+++ b/R/dashboardPage.R
@@ -12,7 +12,7 @@
 #' @param freshTheme A skin powered by the fresh package. Not compatible with skin.
 #' See \url{https://dreamrs.github.io/fresh/articles/vars-shinydashboard.html}.
 #' @param preloader bs4Dash uses waiter (see \url{https://waiter.john-coene.com/#/}).
-#' Pass a list like \code{list(html = spin_1(), color = "#333e48")} to configure \link[waiter]{waiter_show_on_load} (refer to
+#' Pass a list like \code{list(html = spin_1(), color = "#333e48")} to configure \link[waiter]{waiterShowOnLoad} (refer to
 #' the package help for all styles).
 #' @param options Extra option to overwrite the vanilla AdminLTE configuration. See
 #' \url{https://adminlte.io/themes/AdminLTE/documentation/index.html#adminlte-options}.
@@ -177,8 +177,8 @@ bs4DashPage <- function(header, sidebar, body, controlbar = NULL, footer = NULL,
         class = if (sidebarDisabled) "layout-top-nav",
         if (!is.null(preloader)) {
           shiny::tagList(
-            waiter::use_waiter(), # dependencies
-            do.call(waiter_show_on_load, preloader)
+            waiter::useWaiter(), # dependencies
+            do.call(waiterShowOnLoad, preloader)
           )
         },
         onload = if (!is.null(preloader)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -707,7 +707,7 @@ validateIcon <- function (icon)
 
 
 
-waiter_show_on_load <- function(
+waiterShowOnLoad <- function(
   html = waiter::spin_1(), color = "#333e48"
 ){
   
@@ -715,11 +715,11 @@ waiter_show_on_load <- function(
   html <- gsub("\n", "", html)
   
   show <- sprintf(
-    "show_waiter(
-      null,
-      html = '%s', 
-      color = '%s'
-    );",
+    "waiter.show({
+      id: null,
+      html: '%s', 
+      color: '%s'
+    });",
     html, color
   )
   

--- a/vignettes/css-preloader.Rmd
+++ b/vignettes/css-preloader.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 ## How to set up a preloader?
 
-Pass the argument `preloader` to the `dashboardPage()` function. It expects a list containing all parameters necessary to `waiter::waiter_show_on_load`. The duration is automatically handled by listening to the `shiny:idle` [event](https://shiny.rstudio.com/articles/js-events.html). Please have a look to the 
+Pass the argument `preloader` to the `dashboardPage()` function. It expects a list containing all parameters necessary to `waiter::waiterShowOnLoad`. The duration is automatically handled by listening to the `shiny:idle` [event](https://shiny.rstudio.com/articles/js-events.html). Please have a look to the 
 `{waiter}` [documentation](https://waiter.john-coene.com/) for more details.
 
 That's all!


### PR DESCRIPTION
I've made updates to waiter last month, and more this month (currently on its way to CRAN) that will break things here. 

To be fair I don't break anything directly, I've changed much of the JavaScript and thus it breaks this copied function.

https://github.com/RinteRface/bs4Dash/blob/07ccfd1e916732c58cfce07951d58bdf0aa6ba8e/R/utils.R#L710

I'm fine with this remaining in the package but note that it already exists in waiter: https://github.com/JohnCoene/waiter/blob/8967844607f7ec7cc03025adb4a3685cc04310fb/R/waiter.R#L158

It used to be `show_waiter(arg1, arg2, ...)` it's now `waiter.show({})`.

I'm also going to deprecate snake_case functions from the UI in favour of camelCase, that's very long-term though. 