### PR TITLE
Fix progress bar scaling & add `id` param

### DIFF
--- a/R/useful-items.R
+++ b/R/useful-items.R
@@ -549,7 +549,7 @@ bs4CarouselItem <- function(..., caption = NULL, active = FALSE) {
 #' @export
 bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped = FALSE, 
                             animated = FALSE, status = "primary", size = NULL, 
-                            label = NULL) {
+                            label = NULL, id = NULL) {
   
   if (!is.null(status)) validateStatusPlus(status)
   stopifnot(value >= min)
@@ -567,6 +567,7 @@ bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped
   
   # wrapper
   barTag <- shiny::tags$div(
+    id = id,
     class = barCl, 
     role = "progressbar", 
     `aria-valuenow` = value, 
@@ -598,7 +599,8 @@ bs4MultiProgressBar <-
     animated = FALSE,
     status = "primary",
     size = NULL,
-    label = NULL
+    label = NULL,
+    id = NULL
   ) {
     status <- verify_compatible_lengths(value, status)
     striped <- verify_compatible_lengths(value, striped)
@@ -649,7 +651,7 @@ bs4MultiProgressBar <-
     # wrapper class
     progressCl <- if (isTRUE(vertical)) "progress vertical" else "progress mb-3"
     if (!is.null(size)) progressCl <- paste0(progressCl, " progress-", size)
-    progressTag <- shiny::tags$div(class = progressCl)
+    progressTag <- shiny::tags$div(class = progressCl, id = id)
     progressTag <- shiny::tagAppendChild(progressTag, barSegs)
     progressTag
   }

--- a/R/useful-items.R
+++ b/R/useful-items.R
@@ -574,10 +574,10 @@ bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped
     `aria-valuemin` = min, 
     `aria-valuemax` = max, 
     style = if (vertical) {
-      paste0("height: ", paste0((value - min) / max, "%"))
+      paste0("height: ", ((value - min) / (max - min) * 100), "%"))
     }
     else {
-      paste0("width: ", paste0((value - min) / max, "%"))
+      paste0("width: ", ((value - min) / (max - min) * 100), "%"))
     }, 
     if(!is.null(label)) label
   )
@@ -626,10 +626,10 @@ bs4MultiProgressBar <-
         `aria-valuemin` = min, 
         `aria-valuemax` = max, 
         style = if (vertical) {
-          paste0("height: ", paste0(value, "%"))
+          paste0("height: ", paste0(((value - min) / (max - min) * 100), "%"))
         }
         else {
-          paste0("width: ", paste0(value, "%"))
+          paste0("width: ", paste0(((value - min) / (max - min) * 100), "%"))
         }, 
         if(!is.null(label)) label
       )
@@ -640,7 +640,7 @@ bs4MultiProgressBar <-
     for (i in seq_along(value)) {
       barSegs[[i]] <- 
         bar_segment(
-          ((value - min) / max * 100)[[i]],
+          value[[i]],
           striped[[i]],
           animated[[i]],
           status[[i]],

--- a/R/useful-items.R
+++ b/R/useful-items.R
@@ -573,12 +573,7 @@ bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped
     `aria-valuenow` = value, 
     `aria-valuemin` = min, 
     `aria-valuemax` = max, 
-    style = if (vertical) {
-      paste0("height: ", ((value - min) / (max - min) * 100), "%"))
-    }
-    else {
-      paste0("width: ", ((value - min) / (max - min) * 100), "%"))
-    }, 
+    style = paste0(ifelse(vertical, "height: ", "width: "), ((value - min) / (max - min) * 100), "%"), 
     if(!is.null(label)) label
   )
   
@@ -625,12 +620,7 @@ bs4MultiProgressBar <-
         `aria-valuenow` = value, 
         `aria-valuemin` = min, 
         `aria-valuemax` = max, 
-        style = if (vertical) {
-          paste0("height: ", paste0(((value - min) / (max - min) * 100), "%"))
-        }
-        else {
-          paste0("width: ", paste0(((value - min) / (max - min) * 100), "%"))
-        }, 
+        style = paste0(ifelse(vertical, "height: ", "width: "), ((value - min) / (max - min) * 100), "%"), 
         if(!is.null(label)) label
       )
     }

--- a/R/useful-items.R
+++ b/R/useful-items.R
@@ -573,10 +573,10 @@ bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped
     `aria-valuemin` = min, 
     `aria-valuemax` = max, 
     style = if (vertical) {
-      paste0("height: ", paste0(value, "%"))
+      paste0("height: ", paste0((value - min) / max, "%"))
     }
     else {
-      paste0("width: ", paste0(value, "%"))
+      paste0("width: ", paste0((value - min) / max, "%"))
     }, 
     if(!is.null(label)) label
   )
@@ -638,7 +638,7 @@ bs4MultiProgressBar <-
     for (i in seq_along(value)) {
       barSegs[[i]] <- 
         bar_segment(
-          value[[i]],
+          ((value - min) / max * 100)[[i]],
           striped[[i]],
           animated[[i]],
           status[[i]],


### PR DESCRIPTION
This fixes the CSS scaling of the progress bars between the `min` and `max` supplied to the function. 
It also adds an `id` parameter to make the progress bar easier to select with CSS.