### PR TITLE
Add more powerful bs4col() and bs4row() functions

### DIFF
--- a/R/grid.R
+++ b/R/grid.R
@@ -58,3 +58,68 @@ column <- function(width, ..., offset = 0) {
     colClass <- paste0(colClass, " offset-sm-", offset)
   shiny::div(class = colClass, ...)
 }
+
+
+#' TBD
+bs4col <- function
+(
+    ...,
+    width = 0,
+    width.xs = NULL, width.md = NULL, width.lg = NULL, width.xl = NULL,
+    offset = NULL,
+    offset.xs = NULL, offset.md = NULL, offset.lg = NULL, offset.xl = NULL,
+    align = NULL, class = c()
+) {
+    colClass = class
+    breakpoints <- c(".xs", "-sm"="", "-md"=".md", "-lg"=".lg", "-xl"=".xl")
+    for (i in seq_along(breakpoints)) {
+        col = paste0("col", names(breakpoints[i]))
+        w = base::get(paste0("width", breakpoints[i]))
+        if (is.null(w)) {
+            if (breakpoints[i] == "") {
+                stop("column width must be 0-12 or 'auto'")
+            }
+        } else if  (w == "auto" || (is.numeric(w) && w >= 1 && w <= 12)) {
+            colClass <- c(colClass, paste0(col, "-", w))
+        } else if (width == 0) {
+            colClass <- c(colClass, col)
+        } else {
+            stop("column width must be 0-12 or 'auto'")
+        }
+        col = paste0("offset", names(breakpoints[i]))
+        w = base::get(paste0("offset", breakpoints[i]))
+        if (is.null(w)) {
+        } else if (is.numeric(w) && w >= 0 && w <= 12) {
+            colClass <- c(colClass, paste0(col, "-", w))
+        } else if (width == 0) {
+            colClass <- c(colClass, col)
+        } else {
+            stop("offset must be 0-12")
+        }
+    }
+    if (!is.null(align)) {
+        if (!align %in% c("start", "center", "end")) {
+            stop("vertical alignment must be start, center or end")
+        }
+        colClass <- c(colClass, paste0("align-self-", align))
+    }
+    shiny::div(class = colClass, ...)
+}
+
+#' TBD
+bs4row <- function(..., align = NULL, justify = NULL, class = c()) {
+    colClass <- c(class, "row")
+    if (!is.null(align)) {
+        if (!align %in% c("start", "center", "end")) {
+            stop("vertical alignment must be start, center or end")
+        }
+        colClass <- c(colClass, paste0("align-self-", align))
+    }
+    if (!is.null(justify)) {
+        if (!align %in% c("start", "center", "end", "around", "between")) {
+            stop("vertical alignment must be start, center, end, around or between")
+        }
+        colClass <- c(colClass, paste0("justify-content-", align))
+    }
+    shiny::div(class = class, ...)
+}


### PR DESCRIPTION
Bootstrap 4 allows unsized columns (equal width), naturally sized columns (auto), vertical alignment of column content and horizontal justification of columns. This concept PR would add two functions to set the appropriate classes.

As is, the `column()` and `fluidRow()` functions are actually somewhat less convenient than using `div(class="col-sm-4", ...)` directly.

Semantics are different w.r.t. column - the `width` is not necessary, might have only content and the columns just be set to equal width default.

I can write docs for this if there is interest. If not, feel free to close PR. 