### PR TITLE
Add support for all colors to `bs4ProgressBar` & `bs4MultiProgressBar`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ License: GPL (>= 2) | file LICENSE
 Imports: 
     shiny (>= 1.6.0),
     htmltools (>= 0.5.1.1),
+    grDevices,
     jsonlite (>= 0.9.16),
     fresh,
     waiter (>= 0.2.3),

--- a/R/cards.R
+++ b/R/cards.R
@@ -135,11 +135,29 @@
 #' @author David Granjon, \email{dgranjon@@ymail.com}
 #'
 #' @export
-bs4Card <- function(..., title = NULL, footer = NULL, status = NULL,
-                    solidHeader = FALSE, background = NULL, width = 6, height = NULL,
-                    collapsible = TRUE, collapsed = FALSE, closable = FALSE, maximizable = FALSE, icon = NULL,
-                    gradient = FALSE, boxToolSize = "sm", elevation = NULL, headerBorder = TRUE, label = NULL, dropdownMenu = NULL,
-                    sidebar = NULL, id = NULL) {
+bs4Card <- function(...,
+                    title = NULL,
+                    footer = NULL,
+                    status = NULL,
+                    solidHeader = FALSE,
+                    background = NULL,
+                    width = 6,
+                    height = NULL,
+                    collapsible = TRUE,
+                    collapsed = FALSE,
+                    closable = FALSE,
+                    maximizable = FALSE,
+                    icon = NULL,
+                    tip_icon = NULL,
+                    gradient = FALSE,
+                    boxToolSize = "sm",
+                    elevation = NULL,
+                    headerBorder = TRUE,
+                    label = NULL,
+                    dropdownMenu = NULL,
+                    sidebar = NULL,
+                    id = NULL) {
+  
 
   if (is.null(status)) solidHeader <- TRUE
   
@@ -242,7 +260,7 @@ bs4Card <- function(..., title = NULL, footer = NULL, status = NULL,
 
   headerTag <- shiny::tags$div(
     class = if (headerBorder) "card-header" else "card-header border-0",
-    shiny::tags$h3(class = "card-title", icon, title)
+    shiny::tags$h3(class = "card-title", tip_icon, icon, title)
   )
   headerTag <- shiny::tagAppendChild(headerTag, cardToolTag)
 

--- a/R/dashboardSidebar.R
+++ b/R/dashboardSidebar.R
@@ -364,7 +364,7 @@ bs4SidebarMenuItem <- function(text, ..., icon = NULL, badgeLabel = NULL, badgeC
   subItems <- list(...)
 
   if (!is.null(icon)) {
-    tagAssert(icon, type = "i")
+    tagAssert(icon, type = c("i", "img"))
     icon$attribs$class <- paste0(icon$attribs$class, " nav-icon")
   }
 

--- a/R/useful-items.R
+++ b/R/useful-items.R
@@ -57,7 +57,16 @@ bs4Badge <- function(..., color, position = c("left", "right"),
   )
 }
 
+#' @title Bootstrap 4 Alert box
+#' 
+#' @param style \code{(character)} Inline style parameters to add
+#' @inherit bs4Dash::bs4Card params return
+#' @export
 
+bs4Alert <- function(..., status = "primary", style = NULL, id = NULL, width = 6) {
+  bs4Dash:::validateStatus(status)
+  shiny::tags$div(class = paste0("alert alert-",status), role = "alert", ..., style = paste0("margin: 6px 5px 6px 15px;", sapply(\(x) {ifelse(grepl(";$", x), x, paste0(x, ";"))}), id = id))
+}
 
 
 #' Bootstrap 4 accordion container
@@ -549,7 +558,7 @@ bs4CarouselItem <- function(..., caption = NULL, active = FALSE) {
 #' @export
 bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped = FALSE, 
                             animated = FALSE, status = "primary", size = NULL, 
-                            label = NULL) {
+                            label = NULL, id = NULL) {
   
   if (!is.null(status)) validateStatusPlus(status)
   stopifnot(value >= min)
@@ -567,17 +576,13 @@ bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped
   
   # wrapper
   barTag <- shiny::tags$div(
+    id = id,
     class = barCl, 
     role = "progressbar", 
     `aria-valuenow` = value, 
     `aria-valuemin` = min, 
     `aria-valuemax` = max, 
-    style = if (vertical) {
-      paste0("height: ", paste0(value, "%"))
-    }
-    else {
-      paste0("width: ", paste0(value, "%"))
-    }, 
+    style = paste0(ifelse(vertical, "height: ", "width: "), ((value - min) / (max - min) * 100), "%"), 
     if(!is.null(label)) label
   )
   
@@ -598,7 +603,8 @@ bs4MultiProgressBar <-
     animated = FALSE,
     status = "primary",
     size = NULL,
-    label = NULL
+    label = NULL,
+    id = NULL
   ) {
     status <- verify_compatible_lengths(value, status)
     striped <- verify_compatible_lengths(value, striped)
@@ -623,12 +629,7 @@ bs4MultiProgressBar <-
         `aria-valuenow` = value, 
         `aria-valuemin` = min, 
         `aria-valuemax` = max, 
-        style = if (vertical) {
-          paste0("height: ", paste0(value, "%"))
-        }
-        else {
-          paste0("width: ", paste0(value, "%"))
-        }, 
+        style = paste0(ifelse(vertical, "height: ", "width: "), ((value - min) / (max - min) * 100), "%"), 
         if(!is.null(label)) label
       )
     }
@@ -649,7 +650,7 @@ bs4MultiProgressBar <-
     # wrapper class
     progressCl <- if (isTRUE(vertical)) "progress vertical" else "progress mb-3"
     if (!is.null(size)) progressCl <- paste0(progressCl, " progress-", size)
-    progressTag <- shiny::tags$div(class = progressCl)
+    progressTag <- shiny::tags$div(class = progressCl, id = id)
     progressTag <- shiny::tagAppendChild(progressTag, barSegs)
     progressTag
   }

--- a/R/useful-items.R
+++ b/R/useful-items.R
@@ -560,7 +560,7 @@ bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped
                             animated = FALSE, status = "primary", size = NULL, 
                             label = NULL, id = NULL) {
   
-  if (!is.null(status)) validateStatusPlus(status)
+  if (!is.null(status)) validateColors(status)
   stopifnot(value >= min)
   stopifnot(value <= max)
   
@@ -570,7 +570,10 @@ bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped
   
   # bar class
   barCl <- "progress-bar"
-  if (!is.null(status)) barCl <- paste0(barCl, " bg-", status)
+  style <- NULL
+  if (!is.null(status) && status %in% validStatusesPlus) barCl <- paste0(barCl, " bg-", status)
+  else if (status %in% validColorsPlus || is_hex_color(status))
+    style <- paste0(style, "background-color: ", col2css(status), ";")
   if (striped) barCl <- paste0(barCl, " progress-bar-striped")
   if (animated) barCl <- paste0(barCl, " progress-bar-animated")
   
@@ -582,7 +585,7 @@ bs4ProgressBar <- function (value, min = 0, max = 100, vertical = FALSE, striped
     `aria-valuenow` = value, 
     `aria-valuemin` = min, 
     `aria-valuemax` = max, 
-    style = paste0(ifelse(vertical, "height: ", "width: "), ((value - min) / (max - min) * 100), "%"), 
+    style = paste0(style, ifelse(vertical, "height: ", "width: "), ((value - min) / (max - min) * 100), "%"), 
     if(!is.null(label)) label
   )
   

--- a/R/useful-items.R
+++ b/R/useful-items.R
@@ -614,7 +614,7 @@ bs4MultiProgressBar <-
     animated <- verify_compatible_lengths(value, animated)
     if (!is.null(label)) label <- verify_compatible_lengths(value, label)
     
-    if (!is.null(status)) lapply(status, function(x) validateStatusPlus(x))
+    if (!is.null(status)) lapply(status, function(x) validateColors(x))
     stopifnot(all(value >= min))
     stopifnot(all(value <= max))
     stopifnot(sum(value) <= max)
@@ -622,7 +622,12 @@ bs4MultiProgressBar <-
     bar_segment <- function(value, striped, animated, status, label) {
       # bar class
       barCl <- "progress-bar"
-      if (!is.null(status)) barCl <- paste0(barCl, " bg-", status)
+      style <- NULL
+      if (!is.null(status) && status %in% validStatusesPlus) barCl <- paste0(barCl, " bg-", status)
+      else if (status %in% validColorsPlus || is_hex_color(status))
+        style <- paste0(style, "background-color: ", col2css(status), ";")
+      
+        
       if (striped) barCl <- paste0(barCl, " progress-bar-striped")
       if (animated) barCl <- paste0(barCl, " progress-bar-animated")
       
@@ -632,7 +637,7 @@ bs4MultiProgressBar <-
         `aria-valuenow` = value, 
         `aria-valuemin` = min, 
         `aria-valuemax` = max, 
-        style = paste0(ifelse(vertical, "height: ", "width: "), ((value - min) / (max - min) * 100), "%"), 
+        style = paste0(style, ifelse(vertical, "height: ", "width: "), ((value - min) / (max - min) * 100), "%"), 
         if(!is.null(label)) label
       )
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,8 +20,8 @@ tagAssert <- function(tag, type = NULL, class = NULL, allowUI = TRUE) {
     return()
   }
   
-  if (!is.null(type) && tag$name != type) {
-    stop("Expected tag to be of type ", type)
+  if (!is.null(type) && !tag$name %in% type) {
+    stop("Expected tag to be of type(s) ", paste0(type, collapse = ", "))
   }
   
   if (!is.null(class)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -212,6 +212,21 @@ validateStatusPlus <- function(status) {
 #' @keywords internal
 validStatusesPlus <- c(validStatuses, validNuances, validColors)
 
+validColorsPlus <- c(grDevices::colours(), validStatusesPlus)
+
+is_hex_color <- function(color) {
+  grepl("^\\#[a-fA-F0-9]{3,6}", color)
+}
+is_rgba_color <- function(color) {
+  grepl("^rgba\\(", color)
+}
+validateColors <- function(color) {
+  if (color %in% validColorsPlus || is_hex_color(color) || is_rgb_color(color))
+    TRUE
+  else
+    stop("Invalid color: ", color, ". Valid colors are hex or rgba formatted or one of the following: ",
+         paste(validColorsPlus, collapse = ", "), ".")
+}
 
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -227,6 +227,13 @@ validateColors <- function(color) {
     stop("Invalid color: ", color, ". Valid colors are hex or rgba formatted or one of the following: ",
          paste(validColorsPlus, collapse = ", "), ".")
 }
+# Create a CSS rgba declaration for a color name
+col2css <- function(color, alpha = NULL) {
+  if (!is_hex_color(color) && !is_rgba_color(color))
+    paste0("rgba(", paste0(c(col2rgb(color), alpha), collapse = ", "), ")")
+  else
+    color
+}
 
 
 


### PR DESCRIPTION
Adds support to the progress bar utility functions for all colors formatted as CSS hex or rgba declarations, or as a color name listed in `grDevices::colors`