### PR TITLE
support tabsetPanel vertical tab width

### DIFF
--- a/R/tabs.R
+++ b/R/tabs.R
@@ -11,6 +11,7 @@
 #' }
 #' @param vertical Whether to displays tabs vertically. Default to FALSE.
 #' @param side Tabs side: \code{"left" or "right"}.
+#' @param width Tab width (when vertical is \code{TRUE}). Default to 2.
 #' @param .list In case of programmatically generated items. See example.
 #' 
 #' @examples
@@ -174,7 +175,7 @@
 #' @export
 tabsetPanel <- function(..., id = NULL, selected = NULL, 
                         type = c("tabs", "pills", "hidden"), 
-                        vertical = FALSE, side = "left", .list = NULL) {
+                        vertical = FALSE, side = "left", width = 2, .list = NULL) {
   
   items <- c(list(...), .list)
   type <- match.arg(type)
@@ -242,13 +243,13 @@ tabsetPanel <- function(..., id = NULL, selected = NULL,
     
     if (side == "left") {
       shiny::fluidRow(
-        shiny::column(width = 2, tabsetMenu),
-        shiny::column(width = 10, tabsetContent)
+        shiny::column(width = width, tabsetMenu),
+        shiny::column(width = 12-width, tabsetContent)
       )
     } else {
       shiny::fluidRow(
-        shiny::column(width = 10, tabsetContent),
-        shiny::column(width = 2, tabsetMenu)
+        shiny::column(width = 12-width, tabsetContent),
+        shiny::column(width = width, tabsetMenu)
       )
     }
   } else {

--- a/man/dashboardControlbar.Rd
+++ b/man/dashboardControlbar.Rd
@@ -27,6 +27,7 @@ controlbarMenu(
   type = c("tabs", "pills", "hidden"),
   vertical = FALSE,
   side = "left",
+  width = 2,
   .list = NULL
 )
 

--- a/man/tabsetPanel.Rd
+++ b/man/tabsetPanel.Rd
@@ -11,6 +11,7 @@ tabsetPanel(
   type = c("tabs", "pills", "hidden"),
   vertical = FALSE,
   side = "left",
+  width = 2,
   .list = NULL
 )
 }
@@ -34,6 +35,8 @@ tab will be selected.}
 \item{vertical}{Whether to displays tabs vertically. Default to FALSE.}
 
 \item{side}{Tabs side: \code{"left" or "right"}.}
+
+\item{width}{Tab width (when vertical is \code{TRUE}). Default to 2.}
 
 \item{.list}{In case of programmatically generated items. See example.}
 }


### PR DESCRIPTION
Hi @DivadNojnarg first of all many thanks for bs4Dash, really great!
Here's a small PR to give more flexibility in `tabsetPanel`, adding a vertical tab `width` arg. Indeed, when using the `vertical` mode, depending on the `tabPanel` title text length, the default width of 2, which is hardcoded now, becomes a constraint. As a result text of the tab content is overlaying the title. To fix this, a simple way is to have control on the tab width. In my case I had some of the tabPanel titles for which a tab width of 3 is more appropriate.
This `width` arg can be set to 2 by default to keep backward compatibility, let me know if it is ok for you.

Best
Emmanuel